### PR TITLE
Refactor type of random2Response

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,15 +53,8 @@ func random(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-type successMessage struct {
-	Message int `json:"success"`
-}
-type failMessage struct {
-	Message int `json:"fail"`
-}
 type random2Response struct {
-	// successMesage or failMessage を取りたいが書き方がわからない
-	Results []interface{} `json:"results"`
+	Results []map[string]int `json:"results"`
 }
 
 // 10回randして下記メッセージの配列を返す
@@ -70,13 +63,13 @@ type random2Response struct {
 func random2(w http.ResponseWriter, req *http.Request) {
 	fmt.Println("request to random2")
 	threshold := 50
-	results := make([]interface{}, 10)
+	results := make([]map[string]int, 10)
 	for i := range results {
 		v := rand.Intn(100)
 		if v >= threshold {
-			results[i] = successMessage{v}
+			results[i] = map[string]int{"success": v}
 		} else {
-			results[i] = failMessage{v}
+			results[i] = map[string]int{"fail": v}
 		}
 	}
 


### PR DESCRIPTION
# 修正内容
#1 を修正する。
close #1 

# 修正方法
jsonタグが異なる構造体を配列に入れるために`[]interface{}`としていた箇所を`[]map[string]int`として、jsonタグではなくmapで指定する。

# 別案
有識者によるといくつか選択肢があるよう

- 別のinterfaceを作成してそれを指定する。JSONタグの異なる構造体でそのinterfaceを満たすようにする
- MarshalJSONを実装したinterfaceで型アサーション実装して、JSONタグの異なる構造体を代入可能にする
- JSONタグのomitemptyを利用して1つの構造体で宣言する。0値のときに利用できないがなんとかなるらしい
